### PR TITLE
Adiciona configurações de segurança para prod

### DIFF
--- a/cookTogether/settings.py
+++ b/cookTogether/settings.py
@@ -27,13 +27,34 @@ if os.getenv("DJANGO_ENV") == "prod":
     # SECURITY WARNING: don't run with debug turned on in production!
     DEBUG = False
 
-    ALLOWED_HOSTS = ["backend"]
+    ALLOWED_HOSTS = ['cooktogether.duckdns.org']
 
     # SECURITY WARNING: keep the secret key used in production secret!
     SECRET_KEY = f'{os.getenv("DJANGO_SECRET_KEY")}'
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
+    CSRF_TRUSTED_ORIGINS = ['https://cooktogether.duckdns.org']
 
+    # Protects against MIME type sniffing attacks by enabling the header X-Content-Type-Options: nosniff
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    # Enables the browser’s XSS filter by setting the header X-XSS-Protection: 1; mode=block
+    SECURE_BROWSER_XSS_FILTER = True
+
+    # This setting adds the X-Frame-Options header to all HTTP responses. This protects against clickjacking attacks
+    X_FRAME_OPTIONS = 'DENY'
+
+    # Force HTTPS connections only
+    SECURE_HSTS_SECONDS = 31536000  # 1 year
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+
+    # Force HTTPS connections. Redundant because of NGINX, but good to have
+    SECURE_SSL_REDIRECT = True
+    # Trust that the connection is secure by looking at the header X-Forwarded-Proto set by NGINX
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+    # Database
+    # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
@@ -46,7 +67,7 @@ if os.getenv("DJANGO_ENV") == "prod":
         }
     }
 
-    SB_BUCKET_NAME = "recipes_dev"
+    SB_BUCKET_NAME = "recipes"
 
 else:
     DEBUG = True
@@ -118,10 +139,6 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'cookTogether.wsgi.application'
-
-
-# Database
-# https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 
 
 # Password validation

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -58,7 +58,7 @@ http {
 
         # Proxy pass to Django application
         location / {
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
### Descrição

Este PR adiciona configurações adicionais no arquivo `settings.py` e `deploy/nginx.conf` que visam aumentar a segurança da aplicação quando executada no ambiente produtivo.

### Tipo de mudança

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Melhorias na documentação
- [ ] Refatoração de código
- [ ] Testes
- [x] Outros (Melhoria de segurança)

### Checklist

- [x] O código segue o padrão de estilo definido.
- [ ] Testes foram adicionados/atualizados.
- [ ] A documentação foi atualizada (se aplicável).
- [ ] Nenhuma dependência nova foi adicionada sem aprovação.

### Mudanças realizadas

#### Adição de configurações no arquivo `settings.py`
Foram adicionadas algumas configurações a fim de melhorar a segurança e diminuir a superfície de ataque da aplicação quando executada em produção, visto que ela é exposta diretamente a internet.

Configurações adicionadas:
- `CSRF_TRUSTED_ORIGINS = ['https://cooktogether.duckdns.org']`
Define a lista de origens confiáveis para validação CSRF.
- `SECURE_CONTENT_TYPE_NOSNIFF = True`
Ativa o header `X-Content-Type-Options: nosniff`, que protege contra ataques sniffing de tipo MIME.
- `SECURE_BROWSER_XSS_FILTER = True`
Ativa o header `X-XSS-Protection: 1; mode=block`, que protege contra ataques de Cross-Site Scripting (XSS).
- `X_FRAME_OPTIONS = 'DENY'`
Adiciona o header `X-Frame-Options`, prevenindo a inclusão da aplicação em iframes para evitar ataques de clickjacking.
- `SECURE_HSTS_SECONDS = 31536000`, `SECURE_HSTS_INCLUDE_SUBDOMAINS = True` e `SECURE_HSTS_PRELOAD = True`
Forçam o uso de HTTPS por meio do HTTP Strict Transport Security (HSTS).
- `SECURE_SSL_REDIRECT = True`
Redireciona automaticamente todas as requisições HTTP para HTTPS. Embora já seja feito pelo NGINX, é uma medida adicional de segurança.
- `SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')`
Configura o header `X-Forwarded-Proto` para que caso seu valor seja 'https', o Django reconheça a requisição como segura (isto é, feita via HTTPS).

#### Edição de header no arquivo `deploy/nginx.conf`
O header `X-Forwarded-Host` foi substituído pelo header Host para alinhar com as novas configurações do `settings.py`, garantindo a correta validação do token CSRF. O header Host transmite o hostname da requisição, permitindo a validação de domínio a partir da variável `CSRF_TRUSTED_ORIGINS`.
